### PR TITLE
fix regex for not fitting header and over fitting image tag removement

### DIFF
--- a/lib/mailparse.go
+++ b/lib/mailparse.go
@@ -50,7 +50,7 @@ func (m Mail2Most) parseHTML(b []byte, profile int) ([]byte, error) {
 
 	// Strip out HTML header, since we don't really need it.
 	// works not as intended i think
-	hb := regexp.MustCompile(`(?i)<html.*/head>`)
+	hb := regexp.MustCompile(`(?i)<html((.|\n)*)\/head>`)
 	b = hb.ReplaceAll(b, []byte(""))
 
 	// Try to cut out the rest of a reply that comes from Outlook.  :)
@@ -139,7 +139,7 @@ func (m Mail2Most) parseHTML(b []byte, profile int) ([]byte, error) {
 	b = sp.ReplaceAll(b, []byte("$1"))
 
 	// Remove all <img> tags that don't point to websites.
-	im := regexp.MustCompile(`<img.+src=[^h][^t][^>]*?>`)
+	im := regexp.MustCompile(`<img.+?src=[\"'](.+?)[\"'].*?>`)
 	b = im.ReplaceAll(b, []byte(""))
 
 	// Remove excessive <br>s

--- a/lib/mailparse_test.go
+++ b/lib/mailparse_test.go
@@ -24,6 +24,10 @@ func TestParseHTML(t *testing.T) {
 
 	tests := []string{
 		"<html></head>", // this works quite strange and should be refactored maybe
+		`<html>
+		<head>
+		foo
+		</head>`,
 		`<div class="ms-outlook-ios-signature">
 		foo`,
 		"Sent with BlackBerry Work",
@@ -36,8 +40,7 @@ func TestParseHTML(t *testing.T) {
 		`<div></div>`,
 		`<o:p foo></o:p>`,
 		`<span foo></span>`,
-		`<img src="...">`,
-		`<img src='...'>`,
+		`<img width="42" height="42" src="https://foo.bar/img.png">`,
 		`<p></p>`,
 		`<blockquote foo>`,
 		`Sent from foo`,

--- a/lib/mailparse_test.go
+++ b/lib/mailparse_test.go
@@ -40,6 +40,8 @@ func TestParseHTML(t *testing.T) {
 		`<div></div>`,
 		`<o:p foo></o:p>`,
 		`<span foo></span>`,
+		`<img src="...">`,
+		`<img src='...'>`,
 		`<img width="42" height="42" src="https://foo.bar/img.png">`,
 		`<p></p>`,
 		`<blockquote foo>`,


### PR DESCRIPTION
`(?i)<html.*/head>` remove of head tags doesn't work because of multi lines.

`<img.+src=[^h][^t][^>]*?>` matches simply everything what is in a HTML mail because of `[^>]`